### PR TITLE
Update - See Changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,31 @@
 
 ---
 
+## [v1.3.3](https://github.com/jdhillen/vue-template/releases/tag/1.3.3) - 2024-08-02
+
+### Update
+
+- version bump => v1.3.3
+- axios => v1.7.3
+- vue => v3.4.35
+- vue-router => v4.4.2
+- @vitejs/plugin-vue => v5.1.2
+- @vue/compiler-sfc => v3.4.35
+- Renamed DefaultStore to global
+- Renamed prettier scripts in package.json
+- Fixed issue with Services example when calling an external API
+
+### Added
+
+- jsconfig.json for path aliasing completion in VSCode
+- "type": "module" in package.json
+
+### Removed
+
+- Example Services API call
+
+---
+
 ## [v1.3.2](https://github.com/jdhillen/vue-template/releases/tag/1.3.2) - 2024-07-27
 
 ### Update

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "paths": {
+      "@/*": [
+        "./src/*"
+      ]
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,21 +1,21 @@
 {
   "name": "vue-template",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vue-template",
-      "version": "1.3.2",
+      "version": "1.3.3",
       "dependencies": {
-        "axios": "^1.7.2",
+        "axios": "^1.7.3",
         "pinia": "^2.2.0",
-        "vue": "^3.4.34",
-        "vue-router": "^4.4.0"
+        "vue": "^3.4.35",
+        "vue-router": "^4.4.2"
       },
       "devDependencies": {
-        "@vitejs/plugin-vue": "^5.1.1",
-        "@vue/compiler-sfc": "^3.4.34",
+        "@vitejs/plugin-vue": "^5.1.2",
+        "@vue/compiler-sfc": "^3.4.35",
         "sass": "^1.77.8",
         "vite": "^5.3.5",
         "vite-plugin-vue-devtools": "^7.3.7"
@@ -556,10 +556,11 @@
       "license": "MIT"
     },
     "node_modules/@vitejs/plugin-vue": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-5.1.1.tgz",
-      "integrity": "sha512-sDckXxlHpMsjRQbAH9WanangrfrblsOd3pNifePs+FOHjJg1jfWq5L/P0PsBRndEt3nmdUnmvieP8ULDeX5AvA==",
+      "version": "5.1.2",
+      "resolved": "https://mirrors.garmin.com/repository/npm-it-frontend/@vitejs/plugin-vue/-/plugin-vue-5.1.2.tgz",
+      "integrity": "sha512-nY9IwH12qeiJqumTCLJLE7IiNx7HZ39cbHaysEUd+Myvbz9KAqd2yq+U01Kab1R/H1BmiyM2ShTYlNH32Fzo3A==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": "^18.0.0 || >=20.0.0"
       },
@@ -637,49 +638,53 @@
       }
     },
     "node_modules/@vue/compiler-core": {
-      "version": "3.4.34",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.4.34.tgz",
-      "integrity": "sha512-Z0izUf32+wAnQewjHu+pQf1yw00EGOmevl1kE+ljjjMe7oEfpQ+BI3/JNK7yMB4IrUsqLDmPecUrpj3mCP+yJQ==",
+      "version": "3.4.35",
+      "resolved": "https://mirrors.garmin.com/repository/npm-it-frontend/@vue/compiler-core/-/compiler-core-3.4.35.tgz",
+      "integrity": "sha512-gKp0zGoLnMYtw4uS/SJRRO7rsVggLjvot3mcctlMXunYNsX+aRJDqqw/lV5/gHK91nvaAAlWFgdVl020AW1Prg==",
+      "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.24.7",
-        "@vue/shared": "3.4.34",
+        "@vue/shared": "3.4.35",
         "entities": "^4.5.0",
         "estree-walker": "^2.0.2",
         "source-map-js": "^1.2.0"
       }
     },
     "node_modules/@vue/compiler-dom": {
-      "version": "3.4.34",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.4.34.tgz",
-      "integrity": "sha512-3PUOTS1h5cskdOJMExCu2TInXuM0j60DRPpSCJDqOCupCfUZCJoyQmKtRmA8EgDNZ5kcEE7vketamRZfrEuVDw==",
+      "version": "3.4.35",
+      "resolved": "https://mirrors.garmin.com/repository/npm-it-frontend/@vue/compiler-dom/-/compiler-dom-3.4.35.tgz",
+      "integrity": "sha512-pWIZRL76/oE/VMhdv/ovZfmuooEni6JPG1BFe7oLk5DZRo/ImydXijoZl/4kh2406boRQ7lxTYzbZEEXEhj9NQ==",
+      "license": "MIT",
       "dependencies": {
-        "@vue/compiler-core": "3.4.34",
-        "@vue/shared": "3.4.34"
+        "@vue/compiler-core": "3.4.35",
+        "@vue/shared": "3.4.35"
       }
     },
     "node_modules/@vue/compiler-sfc": {
-      "version": "3.4.34",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.4.34.tgz",
-      "integrity": "sha512-x6lm0UrM03jjDXTPZgD9Ad8bIVD1ifWNit2EaWQIZB5CULr46+FbLQ5RpK7AXtDHGjx9rmvC7QRCTjsiGkAwRw==",
+      "version": "3.4.35",
+      "resolved": "https://mirrors.garmin.com/repository/npm-it-frontend/@vue/compiler-sfc/-/compiler-sfc-3.4.35.tgz",
+      "integrity": "sha512-xacnRS/h/FCsjsMfxBkzjoNxyxEyKyZfBch/P4vkLRvYJwe5ChXmZZrj8Dsed/752H2Q3JE8kYu9Uyha9J6PgA==",
+      "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.24.7",
-        "@vue/compiler-core": "3.4.34",
-        "@vue/compiler-dom": "3.4.34",
-        "@vue/compiler-ssr": "3.4.34",
-        "@vue/shared": "3.4.34",
+        "@vue/compiler-core": "3.4.35",
+        "@vue/compiler-dom": "3.4.35",
+        "@vue/compiler-ssr": "3.4.35",
+        "@vue/shared": "3.4.35",
         "estree-walker": "^2.0.2",
         "magic-string": "^0.30.10",
-        "postcss": "^8.4.39",
+        "postcss": "^8.4.40",
         "source-map-js": "^1.2.0"
       }
     },
     "node_modules/@vue/compiler-ssr": {
-      "version": "3.4.34",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.4.34.tgz",
-      "integrity": "sha512-8TDBcLaTrFm5rnF+Qm4BlliaopJgqJ28Nsrc80qazynm5aJO+Emu7y0RWw34L8dNnTRdcVBpWzJxhGYzsoVu4g==",
+      "version": "3.4.35",
+      "resolved": "https://mirrors.garmin.com/repository/npm-it-frontend/@vue/compiler-ssr/-/compiler-ssr-3.4.35.tgz",
+      "integrity": "sha512-7iynB+0KB1AAJKk/biENTV5cRGHRdbdaD7Mx3nWcm1W8bVD6QmnH3B4AHhQQ1qZHhqFwzEzMwiytXm3PX1e60A==",
+      "license": "MIT",
       "dependencies": {
-        "@vue/compiler-dom": "3.4.34",
-        "@vue/shared": "3.4.34"
+        "@vue/compiler-dom": "3.4.35",
+        "@vue/shared": "3.4.35"
       }
     },
     "node_modules/@vue/devtools-api": {
@@ -725,10 +730,55 @@
         "rfdc": "^1.4.1"
       }
     },
+    "node_modules/@vue/reactivity": {
+      "version": "3.4.35",
+      "resolved": "https://mirrors.garmin.com/repository/npm-it-frontend/@vue/reactivity/-/reactivity-3.4.35.tgz",
+      "integrity": "sha512-Ggtz7ZZHakriKioveJtPlStYardwQH6VCs9V13/4qjHSQb/teE30LVJNrbBVs4+aoYGtTQKJbTe4CWGxVZrvEw==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/shared": "3.4.35"
+      }
+    },
+    "node_modules/@vue/runtime-core": {
+      "version": "3.4.35",
+      "resolved": "https://mirrors.garmin.com/repository/npm-it-frontend/@vue/runtime-core/-/runtime-core-3.4.35.tgz",
+      "integrity": "sha512-D+BAjFoWwT5wtITpSxwqfWZiBClhBbR+bm0VQlWYFOadUUXFo+5wbe9ErXhLvwguPiLZdEF13QAWi2vP3ZD5tA==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/reactivity": "3.4.35",
+        "@vue/shared": "3.4.35"
+      }
+    },
+    "node_modules/@vue/runtime-dom": {
+      "version": "3.4.35",
+      "resolved": "https://mirrors.garmin.com/repository/npm-it-frontend/@vue/runtime-dom/-/runtime-dom-3.4.35.tgz",
+      "integrity": "sha512-yGOlbos+MVhlS5NWBF2HDNgblG8e2MY3+GigHEyR/dREAluvI5tuUUgie3/9XeqhPE4LF0i2wjlduh5thnfOqw==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/reactivity": "3.4.35",
+        "@vue/runtime-core": "3.4.35",
+        "@vue/shared": "3.4.35",
+        "csstype": "^3.1.3"
+      }
+    },
+    "node_modules/@vue/server-renderer": {
+      "version": "3.4.35",
+      "resolved": "https://mirrors.garmin.com/repository/npm-it-frontend/@vue/server-renderer/-/server-renderer-3.4.35.tgz",
+      "integrity": "sha512-iZ0e/u9mRE4T8tNhlo0tbA+gzVkgv8r5BX6s1kRbOZqfpq14qoIvCZ5gIgraOmYkMYrSEZgkkojFPr+Nyq/Mnw==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-ssr": "3.4.35",
+        "@vue/shared": "3.4.35"
+      },
+      "peerDependencies": {
+        "vue": "3.4.35"
+      }
+    },
     "node_modules/@vue/shared": {
-      "version": "3.4.34",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.4.34.tgz",
-      "integrity": "sha512-x5LmiRLpRsd9KTjAB8MPKf0CDPMcuItjP0gbNqFCIgL1I8iYp4zglhj9w9FPCdIbHG2M91RVeIbArFfFTz9I3A=="
+      "version": "3.4.35",
+      "resolved": "https://mirrors.garmin.com/repository/npm-it-frontend/@vue/shared/-/shared-3.4.35.tgz",
+      "integrity": "sha512-hvuhBYYDe+b1G8KHxsQ0diDqDMA8D9laxWZhNAjE83VZb5UDaXl9Xnz7cGdDSyiHM90qqI/CyGMcpBpiDy6VVQ==",
+      "license": "MIT"
     },
     "node_modules/ansi-styles": {
       "version": "3.2.1",
@@ -758,9 +808,10 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.2.tgz",
-      "integrity": "sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==",
+      "version": "1.7.3",
+      "resolved": "https://mirrors.garmin.com/repository/npm-it-frontend/axios/-/axios-1.7.3.tgz",
+      "integrity": "sha512-Ar7ND9pU99eJ9GpoGQKhKf58GpUOgnzuaB7ueNQ5BMi0p+LZ5oaEnfF999fAArcTIBwXTCHAmGcHOZJaWPq9Nw==",
+      "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
@@ -965,6 +1016,8 @@
     },
     "node_modules/csstype": {
       "version": "3.1.3",
+      "resolved": "https://mirrors.garmin.com/repository/npm-it-frontend/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
       "license": "MIT"
     },
     "node_modules/debug": {
@@ -2652,15 +2705,16 @@
       }
     },
     "node_modules/vue": {
-      "version": "3.4.34",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-3.4.34.tgz",
-      "integrity": "sha512-VZze05HWlA3ItreQ/ka7Sx7PoD0/3St8FEiSlSTVgb6l4hL+RjtP2/8g5WQBzZgyf8WG2f+g1bXzC7zggLhAJA==",
+      "version": "3.4.35",
+      "resolved": "https://mirrors.garmin.com/repository/npm-it-frontend/vue/-/vue-3.4.35.tgz",
+      "integrity": "sha512-+fl/GLmI4GPileHftVlCdB7fUL4aziPcqTudpTGXCT8s+iZWuOCeNEB5haX6Uz2IpRrbEXOgIFbe+XciCuGbNQ==",
+      "license": "MIT",
       "dependencies": {
-        "@vue/compiler-dom": "3.4.34",
-        "@vue/compiler-sfc": "3.4.34",
-        "@vue/runtime-dom": "3.4.34",
-        "@vue/server-renderer": "3.4.34",
-        "@vue/shared": "3.4.34"
+        "@vue/compiler-dom": "3.4.35",
+        "@vue/compiler-sfc": "3.4.35",
+        "@vue/runtime-dom": "3.4.35",
+        "@vue/server-renderer": "3.4.35",
+        "@vue/shared": "3.4.35"
       },
       "peerDependencies": {
         "typescript": "*"
@@ -2672,57 +2726,18 @@
       }
     },
     "node_modules/vue-router": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-4.4.0.tgz",
-      "integrity": "sha512-HB+t2p611aIZraV2aPSRNXf0Z/oLZFrlygJm+sZbdJaW6lcFqEDQwnzUBXn+DApw+/QzDU/I9TeWx9izEjTmsA==",
+      "version": "4.4.2",
+      "resolved": "https://mirrors.garmin.com/repository/npm-it-frontend/vue-router/-/vue-router-4.4.2.tgz",
+      "integrity": "sha512-1qNybkn2L7QsLzaXs8nvlQmRKp8XF8DCxZys/Jr1JpQcHsKUxTKzTxCVA1G7NfBfwRIBgCJPoujOG5lHCCNUxw==",
+      "license": "MIT",
       "dependencies": {
-        "@vue/devtools-api": "^6.5.1"
+        "@vue/devtools-api": "^6.6.3"
       },
       "funding": {
         "url": "https://github.com/sponsors/posva"
       },
       "peerDependencies": {
         "vue": "^3.2.0"
-      }
-    },
-    "node_modules/vue/node_modules/@vue/reactivity": {
-      "version": "3.4.34",
-      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.4.34.tgz",
-      "integrity": "sha512-ua+Lo+wBRlBEX9TtgPOShE2JwIO7p6BTZ7t1KZVPoaBRfqbC7N3c8Mpzicx173fXxx5VXeU6ykiHo7WgLzJQDA==",
-      "dependencies": {
-        "@vue/shared": "3.4.34"
-      }
-    },
-    "node_modules/vue/node_modules/@vue/runtime-core": {
-      "version": "3.4.34",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.4.34.tgz",
-      "integrity": "sha512-PXhkiRPwcPGJ1BnyBZFI96GfInCVskd0HPNIAZn7i3YOmLbtbTZpB7/kDTwC1W7IqdGPkTVC63IS7J2nZs4Ebg==",
-      "dependencies": {
-        "@vue/reactivity": "3.4.34",
-        "@vue/shared": "3.4.34"
-      }
-    },
-    "node_modules/vue/node_modules/@vue/runtime-dom": {
-      "version": "3.4.34",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.4.34.tgz",
-      "integrity": "sha512-dXqIe+RqFAK2Euak4UsvbIupalrhc67OuQKpD7HJ3W2fv8jlqvI7szfBCsAEcE8o/wyNpkloxB6J8viuF/E3gw==",
-      "dependencies": {
-        "@vue/reactivity": "3.4.34",
-        "@vue/runtime-core": "3.4.34",
-        "@vue/shared": "3.4.34",
-        "csstype": "^3.1.3"
-      }
-    },
-    "node_modules/vue/node_modules/@vue/server-renderer": {
-      "version": "3.4.34",
-      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.4.34.tgz",
-      "integrity": "sha512-GeyEUfMVRZMD/mZcNONEqg7MiU10QQ1DB3O/Qr6+8uXpbwdlmVgQ5Qs1/ZUAFX1X2UUtqMoGrDRbxdWfOJFT7Q==",
-      "dependencies": {
-        "@vue/compiler-ssr": "3.4.34",
-        "@vue/shared": "3.4.34"
-      },
-      "peerDependencies": {
-        "vue": "3.4.34"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "vue-template",
-  "version": "1.3.2",
+  "version": "1.3.3",
+  "type": "module",
   "engines": {
     "node": ">=20.0.0"
   },
@@ -8,18 +9,18 @@
     "dev": "vite",
     "build": "vite build",
     "serve": "vite preview",
-    "format": "npx prettier --check .",
-    "format:write": "npx prettier --write ."
+    "prettier": "npx prettier --check .",
+    "prettier:write": "npx prettier --write ."
   },
   "dependencies": {
-    "axios": "^1.7.2",
+    "axios": "^1.7.3",
     "pinia": "^2.2.0",
-    "vue": "^3.4.34",
-    "vue-router": "^4.4.0"
+    "vue": "^3.4.35",
+    "vue-router": "^4.4.2"
   },
   "devDependencies": {
-    "@vitejs/plugin-vue": "^5.1.1",
-    "@vue/compiler-sfc": "^3.4.34",
+    "@vitejs/plugin-vue": "^5.1.2",
+    "@vue/compiler-sfc": "^3.4.35",
     "sass": "^1.77.8",
     "vite": "^5.3.5",
     "vite-plugin-vue-devtools": "^7.3.7"

--- a/src/components/HelloWorld.vue
+++ b/src/components/HelloWorld.vue
@@ -15,8 +15,8 @@
         >Vue 3 Documentation</a
       >
     </p>
-    <button @click="store.increment()">Count: {{ store.count }}</button>
-    <p>Double: {{ store.doubleCount }}</p>
+    <button @click="globalStore.increment()">Count: {{ globalStore.count }}</button>
+    <p>Double: {{ globalStore.doubleCount }}</p>
     <p>
       Edit
       <code>components/HelloWorld.vue</code> to test hot module replacement.
@@ -26,10 +26,10 @@
 
 <!--|== Scripts ================================================================================ -->
 <script setup>
-import { useDefaultStore } from '@/store/DefaultStore';
-import Service from '@/services';
+import { useGlobalStore } from '@/store/global';
+import Services from '@/services';
 
-const store = useDefaultStore();
+const globalStore = useGlobalStore();
 
 const props = defineProps({
   msg: {
@@ -40,8 +40,8 @@ const props = defineProps({
 });
 
 // Example of a Service to make an API call
-Service.getContact().then((response) => {
-  console.log(response.data);
+Services.getPokemon().then((res) => {
+  console.log(res.data);
 });
 </script>
 

--- a/src/services/index.js
+++ b/src/services/index.js
@@ -3,8 +3,8 @@ import axios from 'axios';
 
 // ==|== Axios Client ==============================================================================
 const apiClient = axios.create({
-  baseURL: `https://www.jdhillen.io/api`,
-  withCredentials: false, // This is the default
+  baseURL: `https://pokeapi.co/api/v2`,
+  withCredentials: false,
   headers: {
     Accept: 'application/json',
     'Content-Type': 'application/json'
@@ -14,7 +14,7 @@ const apiClient = axios.create({
 
 // ==|== Export ====================================================================================
 export default {
-  getContact() {
-    return apiClient.get('/resume/contact/1/');
+  getPokemon() {
+    return apiClient.get('/pokemon/ditto');
   }
 };

--- a/src/store/global.js
+++ b/src/store/global.js
@@ -2,7 +2,7 @@
 import { defineStore } from 'pinia';
 
 // ==|== Store =====================================================================================
-export const useDefaultStore = defineStore('default', {
+export const useGlobalStore = defineStore('global', {
   // ==|== State ===================================================================================
   state: () => {
     return {

--- a/vite.config.js
+++ b/vite.config.js
@@ -2,8 +2,7 @@
 import { defineConfig } from 'vite';
 import vue from '@vitejs/plugin-vue';
 import vueDevTools from 'vite-plugin-vue-devtools'
-
-const path = require('path');
+import path from 'path';
 
 // ==|== Config ====================================================================================
 export default defineConfig({


### PR DESCRIPTION
### Update

- version bump => v1.3.3
- axios => v1.7.3
- vue => v3.4.35
- vue-router => v4.4.2
- @vitejs/plugin-vue => v5.1.2
- @vue/compiler-sfc => v3.4.35
- Renamed DefaultStore to global
- Renamed prettier scripts in package.json
- Fixed issue with Services example when calling an external API

### Added

- jsconfig.json for path aliasing completion in VSCode
- "type": "module" in package.json

### Removed

- Example Services API call